### PR TITLE
adds mtu and table to the config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,4 +49,4 @@ wireguard config at the default file location.
 
 Version
 -------
-This is version 0.2.3
+This is version 0.2.4

--- a/README.rst
+++ b/README.rst
@@ -46,3 +46,7 @@ Create a standalone client::
 they would typically be on different machines and would not interfere with one another. Be aware
 of this when generating peer configs on a server node, or on any node that has a pre-existing
 wireguard config at the default file location.
+
+Version
+-------
+This is version 0.2.3

--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -32,6 +32,8 @@ def test_basic_peer():
     assert peer.public_key == public_key(peer.private_key)
 
     assert not peer.peers
+    assert not peer.mtu
+    assert not peer.table
     assert not peer.pre_up
     assert not peer.post_up
     assert not peer.pre_down

--- a/wireguard/config.py
+++ b/wireguard/config.py
@@ -69,7 +69,8 @@ class Config:  # pylint: disable=too-many-public-methods
         Returns the DNS settings of the given peer for the config file
         """
 
-        return value_list_to_comma('DNS', self._peer.dns)
+        if bool(self._peer.dns):    # has items
+            return value_list_to_comma('DNS', self._peer.dns)
 
     @property
     def pre_up(self):

--- a/wireguard/config.py
+++ b/wireguard/config.py
@@ -168,6 +168,20 @@ class Config:  # pylint: disable=too-many-public-methods
         return f'# {self._peer.description}'
 
     @property
+    def mtu(self):
+        """
+        Returns the mtu for this peer
+        """
+        return f'MTU = {self._peer.mtu}'
+
+    @property
+    def table(self):
+        """
+        Returns the table for this peer
+        """
+        return f'Table = {self._peer.table}'
+
+    @property
     def interface(self):
         """
         Returns the Interface section of the config file

--- a/wireguard/config.py
+++ b/wireguard/config.py
@@ -31,8 +31,8 @@ INTERFACE_KEYS = [
 ]
 
 PEER_KEYS = [
-    'allowed_ips',
     'description',
+    'allowed_ips',
     'endpoint',
     'keepalive',
     'preshared_key',
@@ -169,7 +169,7 @@ class Config:  # pylint: disable=too-many-public-methods
         """
         Returns the name/description for this peer as a comment
         """
-        return f'# {self._peer.description}'
+        return f'# Name = {self._peer.description}'
 
     @property
     def mtu(self):

--- a/wireguard/config.py
+++ b/wireguard/config.py
@@ -26,6 +26,8 @@ INTERFACE_KEYS = [
     'pre_down',
     'post_down',
     'save_config',
+    'mtu',
+    'table',
 ]
 
 PEER_KEYS = [

--- a/wireguard/config.py
+++ b/wireguard/config.py
@@ -31,8 +31,8 @@ INTERFACE_KEYS = [
 ]
 
 PEER_KEYS = [
-    'description',
     'allowed_ips',
+    'description',
     'endpoint',
     'keepalive',
     'preshared_key',
@@ -169,7 +169,7 @@ class Config:  # pylint: disable=too-many-public-methods
         """
         Returns the name/description for this peer as a comment
         """
-        return f'# Name = {self._peer.description}'
+        return f'# {self._peer.description}'
 
     @property
     def mtu(self):

--- a/wireguard/config.py
+++ b/wireguard/config.py
@@ -69,8 +69,11 @@ class Config:  # pylint: disable=too-many-public-methods
         Returns the DNS settings of the given peer for the config file
         """
 
-        if bool(self._peer.dns):    # has items
-            return value_list_to_comma('DNS', self._peer.dns)
+        # do not write empty DNS = entry
+        if not bool(self._peer.dns):
+            return None
+
+        return value_list_to_comma('DNS', self._peer.dns)
 
     @property
     def pre_up(self):

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -293,6 +293,10 @@ class Peer:  # pylint: disable=too-many-instance-attributes
     def mtu(self):
         """
         returns the mtu value
+          WG Default = 1420 (dunno and leave it to automatic for best results)
+          if you have to fix mtu depending on outer:
+            ipv6 connections require 1280 as minimum (try 1300,1350,1400)
+            PPPoE = try 1412 or lower
         """
         return self._mtu
 
@@ -300,10 +304,6 @@ class Peer:  # pylint: disable=too-many-instance-attributes
     def mtu(self, value):
         """
         Sets the mtu value
-        - WG Default = 1420 (dunno and leave it to automatic for best results)
-        if you have to fix mtu depending on outer:
-            - ipv6 connections require 1280 as minimum (try 1300,1350,1400)
-            - PPPoE = try 1412 or lower
         """
         if value is not None:
             if not isinstance(value, int):
@@ -316,14 +316,14 @@ class Peer:  # pylint: disable=too-many-instance-attributes
     @property
     def table(self):
         """
-        returns the table value
+        returns the routing table value
         """
         return self._table
 
     @table.setter
     def table(self, value):
         """
-        Sets the table value
+        Sets the routing table value
         """
         if value is not None:
             if not isinstance(value, int):

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -57,8 +57,8 @@ class Peer:  # pylint: disable=too-many-instance-attributes
     post_up = None
     pre_down = None
     post_down = None
-    mtu = None
-    table = None
+    _mtu = None
+    _table = None
 
     _config = None
     peers = None
@@ -120,6 +120,8 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         self.port = port
         self.interface = interface
         self.keepalive = keepalive
+        self.mtu = mtu
+        self.table = table
 
         if save_config is not None:
             self.save_config = save_config
@@ -136,16 +138,6 @@ class Peer:  # pylint: disable=too-many-instance-attributes
                 self.dns.extend(dns)
             else:
                 self.dns.add(dns)
-        if mtu:
-            if mtu >= 68 and mtu <= 1500:
-                self.mtu = mtu
-            else:
-                raise ValueError('MTU out of range (68-1500)')
-        if table:
-            if table < 1 or table >252:
-                self.table = table
-            else:
-                raise ValueError('Table out of range (1-252)')
         if pre_up:
             self.pre_up.append(pre_up)
         if post_up:
@@ -296,6 +288,47 @@ class Peer:  # pylint: disable=too-many-instance-attributes
             value = max(value, KEEPALIVE_MINIMUM)
 
         self._keepalive = value
+
+    @property
+    def mtu(self):
+        """
+        returns the mtu value
+        """
+        return self._mtu
+
+    @mtu.setter
+    def mtu(self, value):
+        """
+        Sets the mtu value
+        """
+        if value is not None:
+            if not isinstance(value, int):
+                raise ValueError('MTU value must be an integer')
+            elif value < 68 or value > 1500:
+                raise ValueError('MTU value must be in the range 68-1500')
+
+        self._mtu = value
+
+    @property
+    def table(self):
+        """
+        returns the table value
+        """
+        return self._table
+
+    @table.setter
+    def table(self, value):
+        """
+        Sets the table value
+        """
+        if value is not None:
+            if not isinstance(value, int):
+                raise ValueError('Table value must be an integer')
+            elif value < 1 or value > 252:
+                raise ValueError('Table value must be in the range 1-252')
+
+        self._table = value
+
 
     def config(self, config_cls=None):
         """

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -57,6 +57,8 @@ class Peer:  # pylint: disable=too-many-instance-attributes
     post_up = None
     pre_down = None
     post_down = None
+    mtu = None
+    table = None
 
     _config = None
     peers = None
@@ -82,6 +84,8 @@ class Peer:  # pylint: disable=too-many-instance-attributes
                  interface=None,
                  peers=None,
                  config_cls=None,
+                 mtu=None,
+                 table=None,
         ):
 
         self.allowed_ips = IPNetworkSet()
@@ -132,6 +136,16 @@ class Peer:  # pylint: disable=too-many-instance-attributes
                 self.dns.extend(dns)
             else:
                 self.dns.add(dns)
+        if mtu:
+            if mtu >= 68 and mtu <= 1500:
+                self.mtu = mtu
+            else:
+                raise ValueError('MTU out of range (68-1500)')
+        if table:
+            if table < 1 or table >252:
+                self.table = table
+            else:
+                raise ValueError('Table out of range (1-252)')
         if pre_up:
             self.pre_up.append(pre_up)
         if post_up:

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -304,7 +304,8 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('MTU value must be an integer')
-            elif value < 68 or value > 1500: # pylint: disable=no-else-raise
+            # elif value < 68 or value > 1500: # pylint: Unnecessary "elif" after "raise"
+            if value < 68 or value > 1500:  # pylint: disable=no-else-raise
                 raise ValueError('MTU value must be in the range 68-1500')
 
         self._mtu = value
@@ -324,7 +325,8 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('Table value must be an integer')
-            elif value < 1 or value > 252:
+            # elif value < 1 or value > 252: # pylint Unnecessary "elif" after "raise"
+            if value < 1 or value > 252:
                 raise ValueError('Table value must be in the range 1-252')
 
         self._table = value

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -86,7 +86,7 @@ class Peer:  # pylint: disable=too-many-instance-attributes
                  config_cls=None,
                  mtu=None,
                  table=None,
-        ):
+                 ):
 
         self.allowed_ips = IPNetworkSet()
         self.dns = IPAddressSet()
@@ -325,13 +325,17 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         """
         Sets the routing table value
         """
+
         if value is not None:
-            if not isinstance(value, int):
-                raise ValueError('Table value must be an integer')
-            if value == 0 \
-                or value in range(253, 255) \
-                    or value >= (2**31):
-                raise ValueError('Table value must be in the ranges 1-252, 256-2147483647')
+
+            if isinstance(value, int) and not \
+                    (0 < value < 253 or 255 < value < (2**31)):  # pylint: disable=no-else-raise
+                raise ValueError('Table must be in the ranges 1-252, 256-(2°31-1)')
+
+            # special values allowed (auto=default, off=no route created)
+            # ref: https://git.zx2c4.com/wireguard-tools/about/src/man/wg-quick.8
+            elif value not in ('auto', 'off'):
+                raise ValueError('Table must be "auto", "off" or an integer value')
 
         self._table = value
 

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -324,8 +324,10 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('Table value must be an integer')
-            if value < 1 or value > 252:
-                raise ValueError('Table value must be in the range 1-252')
+            if value == 0 \
+                or value in range(253, 255) \
+                    or value >= (2**31):
+                raise ValueError('Table value must be in the ranges 1-252, 256-2147483647')
 
         self._table = value
 

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -330,11 +330,11 @@ class Peer:  # pylint: disable=too-many-instance-attributes
 
             if isinstance(value, int) and not \
                     (0 < value < 253 or 255 < value < (2**31)):  # pylint: disable=no-else-raise
-                raise ValueError('Table must be in the ranges 1-252, 256-(2°31-1)')
+                raise ValueError('Table must be in the ranges 1-252, 256-(2^31-1)')
 
             # special values allowed (auto=default, off=no route created)
             # ref: https://git.zx2c4.com/wireguard-tools/about/src/man/wg-quick.8
-            elif value not in ('auto', 'off'):
+            elif not isinstance(value, str) or value not in ('auto', 'off'):
                 raise ValueError('Table must be "auto", "off" or an integer value')
 
         self._table = value

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -304,8 +304,7 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('MTU value must be an integer')
-            # elif value < 68 or value > 1500: # pylint: Unnecessary "elif" after "raise"
-            if value < 68 or value > 1500:  # pylint: disable=no-else-raise
+            elif value < 68 or value > 1500: # pylint: disable=no-else-raise
                 raise ValueError('MTU value must be in the range 68-1500')
 
         self._mtu = value
@@ -325,8 +324,7 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('Table value must be an integer')
-            # elif value < 1 or value > 252: # pylint Unnecessary "elif" after "raise"
-            if value < 1 or value > 252:
+            elif value < 1 or value > 252: # # pylint: disable=no-else-raise
                 raise ValueError('Table value must be in the range 1-252')
 
         self._table = value

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -328,14 +328,14 @@ class Peer:  # pylint: disable=too-many-instance-attributes
 
         if value is not None:
 
-            if isinstance(value, int) and not \
-                    (0 < value < 253 or 255 < value < (2**31)):  # pylint: disable=no-else-raise
-                raise ValueError('Table must be in the ranges 1-252, 256-(2^31-1)')
-
             # special values allowed (auto=default, off=no route created)
             # ref: https://git.zx2c4.com/wireguard-tools/about/src/man/wg-quick.8
-            elif not isinstance(value, str) or value not in ('auto', 'off'):
+            if isinstance(value, str) and value not in ('auto', 'off'):  # pylint: disable=no-else-raise
                 raise ValueError('Table must be "auto", "off" or an integer value')
+            elif isinstance(value, int) and not \
+                    (0 < value < 253 or 255 < value < (2**31)) \
+                    or isinstance(value, bool):
+                raise ValueError('Table must be in the ranges 1-252, 256-(2^31-1)')
 
         self._table = value
 

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -304,7 +304,7 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('MTU value must be an integer')
-            elif value < 68 or value > 1500:
+            elif value < 68 or value > 1500: # pylint: disable=no-else-raise
                 raise ValueError('MTU value must be in the range 68-1500')
 
         self._mtu = value

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -300,12 +300,16 @@ class Peer:  # pylint: disable=too-many-instance-attributes
     def mtu(self, value):
         """
         Sets the mtu value
+        - WG Default = 1420 (dunno and leave it to automatic for best results)
+        if you have to fix mtu depending on outer:
+            - ipv6 connections require 1280 as minimum (try 1300,1350,1400)
+            - PPPoE = try 1412 or lower
         """
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('MTU value must be an integer')
-            if value < 68 or value > 1500:
-                raise ValueError('MTU value must be in the range 68-1500')
+            if value < 1280 or value > 1420:
+                raise ValueError('MTU value must be in the range 1280-1420')
 
         self._mtu = value
 

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -304,7 +304,7 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('MTU value must be an integer')
-            elif value < 68 or value > 1500: # pylint: disable=no-else-raise
+            if value < 68 or value > 1500:
                 raise ValueError('MTU value must be in the range 68-1500')
 
         self._mtu = value
@@ -324,7 +324,7 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         if value is not None:
             if not isinstance(value, int):
                 raise ValueError('Table value must be an integer')
-            elif value < 1 or value > 252: # # pylint: disable=no-else-raise
+            if value < 1 or value > 252:
                 raise ValueError('Table value must be in the range 1-252')
 
         self._table = value


### PR DESCRIPTION
There is a inoffial description for "Table" and "MTU" on https://github.com/pirate/wireguard-docs#Table. 
Normal Linux kernels support slots between 0 and 255 (http://linux-ip.net/html/routing-tables.html#idm140337857356016). The code within this request will limit "Table" to a value within ranges of 1 to 252,256-(2^31-1) (253-255 do not need an explicit "Table" definition). This is helpful in policy-based routing scenarios. Table can be set to auto (default) or off if the route shall not be created.
The max MTU value could be a constant, as Ethernet II networks have a standard frame size of 1518 bytes. After looking at the WG source there are some suggestions when issuing help(Peer)
If DNS is not set (in plain routed environment) the parameter shall not show up in the config.