### PR TITLE
Allows setting the IP directly via the server subnet argument

### DIFF
--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -3,9 +3,8 @@ import pytest
 
 from subnet import (
     ip_address,
-    ip_network,
-    IPv4Network,
     IPv4Address,
+    IPv6Address,
 )
 
 from wireguard import (
@@ -19,17 +18,38 @@ from wireguard import (
 from wireguard.utils import public_key
 
 
-def test_basic_peer():
-    address = '192.168.0.2'
+@pytest.mark.parametrize(
+    ('ipv4_address', 'ipv6_address',),
+    [
+        ('192.168.0.2', None,),
+        (None, 'fde2:3a65:ca93:3125:1234:abcd:4321:32',),
+        ('192.168.0.2', 'fde2:3a65:ca93:3125:1234:abcd:4321:32',),
+    ])
+def test_basic_peer(ipv4_address, ipv6_address):
+
+    if ipv4_address and ipv6_address:
+        address = [ipv4_address, ipv6_address]
+    elif ipv6_address:
+        address = ipv6_address
+    else:
+        address = ipv4_address
 
     peer = Peer(
         'test-peer',
         address=address,
     )
 
-    assert isinstance(peer.ipv4, IPv4Address)
-    assert str(peer.ipv4) == address
-    assert peer.ipv6 is None
+    if ipv4_address:
+        assert isinstance(peer.ipv4, IPv4Address)
+        assert str(peer.ipv4) == ipv4_address
+    else:
+        assert peer.ipv4 is None
+
+    if ipv6_address:
+        assert isinstance(peer.ipv6, IPv6Address)
+        assert str(peer.ipv6) == ipv6_address
+    else:
+        assert peer.ipv6 is None
 
     assert peer.port == PORT
     assert peer.interface == INTERFACE
@@ -59,7 +79,16 @@ def test_basic_peer():
         if line:
             assert line == '[Interface]'
             break
-    assert f'Address = {address}/32' in config_lines
+
+    if ipv4_address and ipv6_address:
+        assert (
+            f'Address = {ipv4_address}/32,{ipv6_address}/128' in config_lines or
+            f'Address = {ipv6_address}/128,{ipv4_address}/32' in config_lines
+        )
+    elif ipv6_address:
+        assert f'Address = {ipv6_address}/128' in config_lines
+    else:
+        assert f'Address = {ipv4_address}/32' in config_lines
 
     assert '# test-peer' not in config_lines  # Should only be present in Peer section on remote
     assert '[Peer]' not in config_lines  # We haven't configured any peers, so this shouldn't exist

--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -27,8 +27,9 @@ def test_basic_peer():
         address=address,
     )
 
-    assert isinstance(peer.address, IPv4Address)
-    assert str(peer.address) == address
+    assert isinstance(peer.ipv4, IPv4Address)
+    assert str(peer.ipv4) == address
+    assert peer.ipv6 is None
 
     assert peer.port == PORT
     assert peer.interface == INTERFACE
@@ -85,8 +86,9 @@ def test_peer_mtu(mtu):
         mtu=mtu,
     )
 
-    assert isinstance(peer.address, IPv4Address)
-    assert str(peer.address) == address
+    assert isinstance(peer.ipv4, IPv4Address)
+    assert str(peer.ipv4) == address
+    assert peer.ipv6 is None
 
     assert peer.port == PORT
     assert peer.interface == INTERFACE
@@ -148,8 +150,9 @@ def test_peer_dns():
         dns=ip_address(dns),
     )
 
-    assert isinstance(peer.address, IPv4Address)
-    assert str(peer.address) == address
+    assert isinstance(peer.ipv4, IPv4Address)
+    assert str(peer.ipv4) == address
+    assert peer.ipv6 is None
 
     assert peer.port == PORT
     assert peer.interface == INTERFACE

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -571,3 +571,45 @@ def test_server_invalid_table(table, exception_message):
         )
 
     assert exception_message in str(exc.value)
+
+@pytest.mark.parametrize(
+    ('subnet_with_host_bits', 'subnet', 'address',),
+    [
+        ('192.168.0.5/24', '192.168.0.0/24', '192.168.0.5',),
+        ('10.12.2.18/16', '10.12.0.0/16', '10.12.2.18',),
+        ('fde2:3a65:ca93:3125::4523:3425/64', 'fde2:3a65:ca93:3125::/64', 'fde2:3a65:ca93:3125::4523:3425',),
+    ])
+def test_server_subnet_with_host_bits(subnet_with_host_bits, subnet, address):
+
+    server = Server(
+        'test-server',
+        subnet_with_host_bits,
+    )
+
+    assert str(server.subnet) == subnet
+    assert str(server.address) == address
+
+
+@pytest.mark.parametrize(
+    ('subnet', 'address', 'exception_message',),
+    [
+        (False, None, 'that only gives you 1 IP address',),
+        (True, None, 'that only gives you 1 IP address',),
+        (None, None, 'does not appear to be an IPv4 or IPv6 network',),
+        ('beep', None, 'does not appear to be an IPv4 or IPv6 network',),
+        (-1, None, 'does not appear to be an IPv4 or IPv6 network',),
+        ('192.168.1.12/24', '192.168.1.1', 'both an address AND a subnet',),
+        ('192.168.1.12/32', None, 'that only gives you 1 IP address',),
+        ('fde2:3a65:ca93:3125::4523:3425/128', None, 'that only gives you 1 IP address',),
+        ('fde2:3a65:ca93:3125::4523:3425/64', 'fde2:3a65:ca93:3125::5234:a423', 'both an address AND a subnet',),
+    ])
+def test_server_invalid_subnet(subnet, address, exception_message):
+
+    with pytest.raises(ValueError) as exc:
+        server = Server(
+            'test-server',
+            subnet,
+            address=address,
+        )
+
+    assert exception_message in str(exc.value)

--- a/wireguard/config.py
+++ b/wireguard/config.py
@@ -61,6 +61,9 @@ class Config:  # pylint: disable=too-many-public-methods
         Returns the subnets that the remote peer should route to this peer
         """
 
+        if not self._peer.allowed_ips:
+            return None
+
         return value_list_to_comma('AllowedIPs', self._peer.allowed_ips)
 
     @property
@@ -69,8 +72,7 @@ class Config:  # pylint: disable=too-many-public-methods
         Returns the DNS settings of the given peer for the config file
         """
 
-        # do not write empty DNS = entry
-        if not bool(self._peer.dns):
+        if not self._peer.dns:
             return None
 
         return value_list_to_comma('DNS', self._peer.dns)
@@ -190,7 +192,12 @@ class Config:  # pylint: disable=too-many-public-methods
         """
         Returns the Address for this peer
         """
-        return f'Address = {self._peer.address}/{self._peer.address.max_prefixlen}'
+
+        values = []
+        for ip in self._peer.address:  # pylint: disable=invalid-name
+            values.append(f'{ip}/{ip.max_prefixlen}')
+
+        return value_list_to_comma('Address', values)
 
     @property
     def description(self):
@@ -364,7 +371,15 @@ class ServerConfig(Config):
         """
         Returns the Address for this Server
         """
-        return f'Address = {self._peer.address}/{self._peer.subnet.prefixlen}'
+
+        values = []
+        if self._peer.ipv4:
+            values.append(f'{self._peer.ipv4}/{self._peer.ipv4_subnet.prefixlen}')
+
+        if self._peer.ipv6:
+            values.append(f'{self._peer.ipv6}/{self._peer.ipv6_subnet.prefixlen}')
+
+        return value_list_to_comma('Address', values)
 
     @property
     def peers_filename(self):

--- a/wireguard/peer.py
+++ b/wireguard/peer.py
@@ -3,6 +3,8 @@
 from subnet import (
     ip_address,
     ip_network,
+    IPv4Address,
+    IPv6Address,
 )
 
 from .utils import (
@@ -44,7 +46,8 @@ class Peer:  # pylint: disable=too-many-instance-attributes
 
     description = None
     _interface = None
-    _address = None
+    _ipv6_address = None
+    _ipv4_address = None
     _port = None
     _private_key = None
     _public_key = None
@@ -98,10 +101,32 @@ class Peer:  # pylint: disable=too-many-instance-attributes
 
         self.description = description
 
-        if address is None:
-            raise ValueError('Address is required')
+        if not isinstance(address, (list, set, tuple,)):
+            address = [address]
 
-        self.address = address
+        if len(address) > 2:
+            raise ValueError(
+                'You cannot specify more than 2 IPs for this interface: 1 IPv4 + 1 IPv6')
+
+        # pylint: disable=invalid-name
+        for ip in address:
+            if not isinstance(ip, (IPv4Address, IPv6Address,)):
+                ip = ip_address(ip)
+
+            if ip.version == 4:
+                if self.ipv4:
+                    raise ValueError('Cannot set a 2nd IPv4 address.')
+
+                self.ipv4 = ip
+
+            elif ip.version == 6:
+                if self.ipv6:
+                    raise ValueError('Cannot set a 2nd IPv6 address.')
+
+                self.ipv6 = ip
+
+        # pylint: enable=invalid-name
+
         self.endpoint = endpoint
 
         if private_key is None and public_key is None:
@@ -127,12 +152,15 @@ class Peer:  # pylint: disable=too-many-instance-attributes
             self.save_config = save_config
 
         # Always add own address to allowed IPs, to ensure routing at least makes it that far
-        self.allowed_ips.add(ip_network(self.address))
+        for ip in self.address:  # pylint: disable=invalid-name
+            self.allowed_ips.add(ip_network(ip))
+
         if allowed_ips:
             if isinstance(allowed_ips, (list, set, tuple)):
                 self.allowed_ips.extend(allowed_ips)
             else:
                 self.allowed_ips.add(allowed_ips)
+
         if dns:
             if isinstance(dns, (list, set, tuple)):
                 self.dns.extend(dns)
@@ -199,26 +227,71 @@ class Peer:  # pylint: disable=too-many-instance-attributes
         self._interface = value
 
     @property
-    def address(self):
+    def ipv4(self):
         """
-        Returns the IP address for this object
+        Returns the IPv4 address for this object
         """
 
-        if self._address is None:
-            raise AttributeError('Address is not set!')
+        return self._ipv4_address
 
-        return self._address
-
-    @address.setter
-    def address(self, value):
+    @ipv4.setter
+    def ipv4(self, value):
         """
-        Sets the IP address for this connection
+        Sets the IPv4 address for this connection
         """
 
         if value is None:
-            raise ValueError('Address cannot be empty!')
+            self._ipv4_address = None
+            return
 
-        self._address = ip_address(value)
+        if not isinstance(value, IPv4Address):
+            value = ip_address(value)
+
+        if value.version != 4:
+            raise ValueError('Cannot use IPv6 value to set IPv4')
+
+        self._ipv4_address = value
+
+    @property
+    def ipv6(self):
+        """
+        Returns the IPv4 address for this object
+        """
+
+        return self._ipv6_address
+
+    @ipv6.setter
+    def ipv6(self, value):
+        """
+        Sets the IPv6 address for this connection
+        """
+
+        if value is None:
+            self._ipv6_address = None
+            return
+
+        if not isinstance(value, IPv6Address):
+            value = ip_address(value)
+
+        if value.version != 6:
+            raise ValueError('Cannot use IPv4 value to set IPv6')
+
+        self._ipv6_address = value
+
+    @property
+    def address(self):
+        """
+        Returns the address(es) for this peer
+        """
+
+        ips = []
+        if self.ipv4 is not None:
+            ips.append(self.ipv4)
+
+        if self.ipv6 is not None:
+            ips.append(self.ipv6)
+
+        return ips
 
     @property
     def private_key(self):

--- a/wireguard/server.py
+++ b/wireguard/server.py
@@ -51,6 +51,7 @@ class Server(Peer):
             raise ValueError('You cannot set more than 2 core subnets: 1 IPv4 + 1 IPv6. '
                              'Use AllowedIPs instead.')
 
+        addresses_from_subnets = []
         for net in subnet:
             if not isinstance(net, (IPv4Network, IPv6Network)):
                 try:
@@ -70,7 +71,7 @@ class Server(Peer):
                     # The user is providing a subnet with host bits set, but `ip_address` does not
                     # allow subnet to be included when parsing the address. Therefore, we chop it
                     # out, leaving only the desired IP.
-                    kwargs['address'] = ip_address(net.split('/')[0])
+                    addresses_from_subnets.append(ip_address(net.split('/')[0]))
 
                     # We've got the desired address, now we can set the subnet appropriately.
                     net = ip_network(net, strict=False)
@@ -93,7 +94,10 @@ class Server(Peer):
                 self.ipv6_subnet = net
 
         if 'address' not in kwargs:
-            kwargs.update({'address': self.unique_address()})
+            if addresses_from_subnets:
+                kwargs.update({'address': addresses_from_subnets})
+            else:
+                kwargs.update({'address': self.unique_address()})
 
         if 'config_cls' not in kwargs:
             kwargs.update({'config_cls': ServerConfig})

--- a/wireguard/server.py
+++ b/wireguard/server.py
@@ -35,46 +35,66 @@ class Server(Peer):
     While not required to have a server<->client setup, this class simplifies doing so
     """
 
-    subnet = None
+    ipv4_subnet = None
+    ipv6_subnet = None
 
     def __init__(self,
                  description,
                  subnet,
                  **kwargs
-            ):
+            ):  # pylint: disable=too-many-branches
 
-        if not isinstance(subnet, (IPv4Network, IPv6Network)):
-            try:
-                # If subnet includes host bits, then ip_network will fail, but we can probably
-                # recover what the user actually wanted to do.
-                subnet = ip_network(subnet)
+        if not isinstance(subnet, (list, set, tuple,)):
+            subnet = [subnet]
 
-            except ValueError as exc:
-                if not isinstance(subnet, str) or '/' not in subnet:
-                    raise exc
+        if len(subnet) > 2:
+            raise ValueError('You cannot set more than 2 core subnets: 1 IPv4 + 1 IPv6. '
+                             'Use AllowedIPs instead.')
 
-                if 'address' in kwargs and kwargs['address'] is not None:
-                    raise ValueError(
-                        'You cannot provide both an address AND a subnet with host bits set!'
-                    ) from exc
+        for net in subnet:
+            if not isinstance(net, (IPv4Network, IPv6Network)):
+                try:
+                    # If subnet includes host bits, then ip_network will fail, but we can probably
+                    # recover what the user actually wanted to do.
+                    net = ip_network(net)
 
-                # The user is providing a subnet with host bits set, but `ip_address` does not
-                # allow subnet to be included when parsing the address. Therefore, we chop it
-                # out, leaving only the desired IP.
-                kwargs['address'] = ip_address(subnet.split('/')[0])
+                except ValueError as exc:
+                    if not isinstance(net, str) or '/' not in net:
+                        raise exc
 
-                # We've got the desired address, now we can set the subnet appropriately.
-                subnet = ip_network(subnet, strict=False)
+                    if 'address' in kwargs and kwargs['address'] is not None:
+                        raise ValueError(
+                            'You cannot provide both an address AND a subnet with host bits set!'
+                        ) from exc
 
-        if subnet.prefixlen == subnet.max_prefixlen:
-            raise ValueError('You cannot use an IPv4 `/32` subnet, nor an IPv6 '
-                             '`/128` subnet as that only gives you 1 IP address '
-                             'to use, and therefore you cannot have any peers!')
+                    # The user is providing a subnet with host bits set, but `ip_address` does not
+                    # allow subnet to be included when parsing the address. Therefore, we chop it
+                    # out, leaving only the desired IP.
+                    kwargs['address'] = ip_address(net.split('/')[0])
 
-        self.subnet = subnet
+                    # We've got the desired address, now we can set the subnet appropriately.
+                    net = ip_network(net, strict=False)
+
+            if net.prefixlen == net.max_prefixlen:
+                raise ValueError('You cannot use an IPv4 `/32` subnet, nor an IPv6 '
+                                 '`/128` subnet as that only gives you 1 IP address '
+                                 'to use, and therefore you cannot have any peers!')
+
+            if net.version == 4:
+                if self.ipv4_subnet:
+                    raise ValueError('You cannot set 2 IPv4 core subnets.')
+
+                self.ipv4_subnet = net
+
+            elif net.version == 6:
+                if self.ipv6_subnet:
+                    raise ValueError('You cannot set 2 IPv6 core subnets.')
+
+                self.ipv6_subnet = net
 
         if 'address' not in kwargs:
-            kwargs.update({'address': subnet.random_ip()})
+            kwargs.update({'address': self.unique_address()})
+
         if 'config_cls' not in kwargs:
             kwargs.update({'config_cls': ServerConfig})
 
@@ -88,8 +108,8 @@ class Server(Peer):
         A simplistic representation of this object
         """
 
-        return (f'<{self.__class__.__name__} iface={self.interface} subnet={self.subnet} '
-                f'address={self.address}>')
+        return (f'<{self.__class__.__name__} iface={self.interface} ipv4={self.ipv4_subnet} '
+                f'ipv6={self.ipv6_subnet} address={self.address}>')
 
     @property
     def service(self):
@@ -108,28 +128,51 @@ class Server(Peer):
 
         return item in self.peers_pubkeys
 
-    def address_exists(self, item):
+    def address_exists_ipv4(self, item):
         """
-        Checks an IP address against the addresses already used by this server and it's peers
+        Checks an IPv4 address against the addresses already used by this server and it's peers
         """
 
-        if not isinstance(item, (IPv4Address, IPv6Address)):
+        if not isinstance(item, IPv4Address):
             item = ip_address(item)
 
-        if item == self.address:
+        if item == self.ipv4:
             return True
 
-        return item in self.peers_addresses
+        return item in self.peers_addresses_ipv4
+
+    def address_exists_ipv6(self, item):
+        """
+        Checks an IPv6 address against the addresses already used by this server and it's peers
+        """
+
+        if not isinstance(item, IPv6Address):
+            item = ip_address(item)
+
+        if item == self.ipv6:
+            return True
+
+        return item in self.peers_addresses_ipv6
 
     @property
-    def peers_addresses(self):
+    def peers_addresses_ipv4(self):
         """
-        Returns all the IP addresses for the peers attached to this server
+        Returns all the IPv4 addresses for the peers attached to this server
         """
 
         if not self.peers:
             return []
-        return [peer.address for peer in self.peers]
+        return [peer.ipv4 for peer in self.peers]
+
+    @property
+    def peers_addresses_ipv6(self):
+        """
+        Returns all the IPv6 addresses for the peers attached to this server
+        """
+
+        if not self.peers:
+            return []
+        return [peer.ipv6 for peer in self.peers]
 
     @property
     def peers_pubkeys(self):
@@ -143,20 +186,55 @@ class Server(Peer):
 
     def unique_address(self, max_address_retries=None):
         """
-        Return an unused address from this server's subnet
+        Return unused addresses from this server's subnets (1 IPv4 + 1 IPv6, if applicable)
+        """
+
+        addresses = []
+
+        if self.ipv4_subnet:
+            addresses.append(self.unique_address_ipv4(max_address_retries))
+
+        if self.ipv6_subnet:
+            addresses.append(self.unique_address_ipv6(max_address_retries))
+
+        return addresses
+
+    def unique_address_ipv4(self, max_address_retries=None):
+        """
+        Return an unused address from this server's IPv4 subnet
         """
 
         if max_address_retries in [None, True]:
             max_address_retries = MAX_ADDRESS_RETRIES
 
-        address = self.subnet.random_ip()
+        address = self.ipv4_subnet.random_ip()
         tries = 0
 
-        while self.address_exists(address):
+        while self.address_exists_ipv4(address):
             if tries >= max_address_retries:
-                raise ValueError('Too many retries to obtain an unused IP address')
+                raise ValueError('Too many retries to obtain an unused IPv4 address')
 
-            address = self.subnet.random_ip()
+            address = self.ipv4_subnet.random_ip()
+            tries += 1
+
+        return address
+
+    def unique_address_ipv6(self, max_address_retries=None):
+        """
+        Return an unused address from this server's IPv6 subnet
+        """
+
+        if max_address_retries in [None, True]:
+            max_address_retries = MAX_ADDRESS_RETRIES
+
+        address = self.ipv6_subnet.random_ip()
+        tries = 0
+
+        while self.address_exists_ipv6(address):
+            if tries >= max_address_retries:
+                raise ValueError('Too many retries to obtain an unused IPv6 address')
+
+            address = self.ipv6_subnet.random_ip()
             tries += 1
 
         return address
@@ -225,14 +303,27 @@ class Server(Peer):
         and optionally updating the peer's data to obtain uniqueness
         """
 
-        if self.address_exists(peer.address):
-            try:
-                if max_address_retries in [False, 0]:
-                    raise ValueError('Not allowed to change the peer IP address due to'
-                                     ' max_address_retries=False (or 0)')
-                peer.address = self.unique_address(max_address_retries)
-            except ValueError as exc:
-                raise ValueError('Could not add peer to this server. It is not unique.') from exc
+        if self.ipv4_subnet and peer.ipv4:
+            if self.address_exists_ipv4(peer.ipv4):
+                try:
+                    if max_address_retries in [False, 0]:
+                        raise ValueError('Not allowed to change the peer IP address due to'
+                                         ' max_address_retries=False (or 0)')
+                    peer.ipv4 = self.unique_address_ipv4(max_address_retries)
+                except ValueError as exc:
+                    raise ValueError(
+                        'Could not add peer to this server. It is not unique.') from exc
+
+        if self.ipv6_subnet and peer.ipv6:
+            if self.address_exists_ipv6(peer.ipv6):
+                try:
+                    if max_address_retries in [False, 0]:
+                        raise ValueError('Not allowed to change the peer IP address due to'
+                                         ' max_address_retries=False (or 0)')
+                    peer.ipv6 = self.unique_address_ipv6(max_address_retries)
+                except ValueError as exc:
+                    raise ValueError(
+                        'Could not add peer to this server. It is not unique.') from exc
 
         if self.pubkey_exists(peer.public_key):
             try:
@@ -241,7 +332,8 @@ class Server(Peer):
                                      ' max_privkey_retries=False (or 0)')
                 peer.private_key = self.unique_privkey(max_privkey_retries)
             except ValueError as exc:
-                raise ValueError('Could not add peer to this server. It is not unique.') from exc
+                raise ValueError(
+                        'Could not add peer to this server. It is not unique.') from exc
 
         peer.peers.add(self)  # This server needs to be a peer of the new peer
         self.peers.add(peer)  # The peer needs to be attached to this server

--- a/wireguard/utils/sets.py
+++ b/wireguard/utils/sets.py
@@ -72,6 +72,11 @@ class IPAddressSet(ClassedSet):
 
         return value
 
+    def __str__(self):
+        string_values = []
+        for ip in self:  # pylint: disable=invalid-name
+            string_values.append(f'{ip.address}/{ip.max_prefixlen}')
+        return ','.join(string_values)
 
 
 class IPNetworkSet(ClassedSet):
@@ -103,6 +108,12 @@ class IPNetworkSet(ClassedSet):
                     f'Could not convert to IP Network: {type(value)}({value})') from exc
 
         return value
+
+    def __str__(self):
+        string_values = []
+        for net in self:
+            string_values.append(f'{str(net.network_address)}/{net.prefixlen}')
+        return ','.join(string_values)
 
 
 class NonStrictIPNetworkSet(IPNetworkSet):


### PR DESCRIPTION
These changes allow a user to set both a server's address and subnet by passing only a `subnet` argument with host bits set, rather than both a subnet and an address.

```python
my_server = Server(
    'my-server-with-only-a-subnet',
    '10.10.1.1/16'
)
```

versus the old way:

```python
my_server = Server(
    'my-server-with-both-a-subnet-and-address',
    '10.10.1.0/16',
    address='10.10.1.1'
)
```

Additionally, it allows both the server and peers to have an IP for v4 and v6. However, only 1 IP of each class is allowed currently. (And allows both of the server's v4/v6 IPs to be set via the `subnet` argument.)

Relevant tests are also included in this PR.

@marneu, please have a look and see if this works the way that you expected when we discussed the feature.